### PR TITLE
Support placeid in details query

### DIFF
--- a/lib/google_places_autocomplete/client.rb
+++ b/lib/google_places_autocomplete/client.rb
@@ -50,10 +50,20 @@ module GooglePlacesAutocomplete
       mashup(self.class.get("/autocomplete/json", :query => options.merge(self.default_options)))
     end
 
-    def details(reference_id)
-      options = {
-        reference: reference_id
-      }
+    def details(options={})
+      placeid = options.delete(:placeid)
+      reference = options.delete(:reference)
+
+      if placeid
+        options = {
+          placeid: placeid
+        }
+      else
+        options = {
+          reference: reference
+        }
+      end
+
       mashup(self.class.get("/details/json", :query => options.merge(self.default_options)))
     end
     


### PR DESCRIPTION
According to Google, the `reference` parameter is deprecated in favor of `placeid`. This commit changes details to accept a hash of options like autocomplete, and uses `placeid` if available, or `reference` if it's not.

I tried running tests, but they failed with `VCR::Errors::InvalidCassetteFormatError`. Not very familiar with VCR, so I didn't spend the time yet fixing the tests. Would be happy to with a little guidance or if I get more time in the next few weeks.