### PR TITLE
Allow additional query params when fetching the place details

### DIFF
--- a/google_places_autocomplete.gemspec
+++ b/google_places_autocomplete.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
-  s.add_dependency 'httparty'
-  s.add_dependency 'hashie'  
+
+  s.add_dependency 'httparty', '0.13.7'
+  s.add_dependency 'hashie'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'fakeweb'
-  s.add_development_dependency 'vcr'  
+  s.add_development_dependency 'vcr'
 end

--- a/lib/google_places_autocomplete/client.rb
+++ b/lib/google_places_autocomplete/client.rb
@@ -51,15 +51,7 @@ module GooglePlacesAutocomplete
     end
 
     def details(options={})
-      placeid = options.delete(:placeid)
-      reference = options.delete(:reference)
-
-      if placeid
-        options[:placeid] = placeid
-      else
-        options[:reference] = reference
-      end
-
+      options.delete(:reference) if options[:placeid]
       mashup(self.class.get("/details/json", :query => options.merge(self.default_options)))
     end
 

--- a/lib/google_places_autocomplete/client.rb
+++ b/lib/google_places_autocomplete/client.rb
@@ -1,16 +1,16 @@
 module GooglePlacesAutocomplete
-  
+
   class Client
     include HTTParty
     base_uri "https://maps.googleapis.com/maps/api/place"
     format :json
-    
+
     attr_reader :api_key
-                
+
     def initialize(options={})
       @api_key = options[:api_key] || GooglePlaces.api_key
     end
-    
+
     def autocomplete(options={})
       sensor = options.delete(:sensor) || false
       types  = options.delete(:types)
@@ -40,12 +40,12 @@ module GooglePlacesAutocomplete
         :userIp => user_ip,
         :quotaUser => quota_user
       }
-      
+
       if types
         types = (types.is_a?(Array) ? types.join('|') : types)
         options.merge!(:types => types)
       end
-      
+
       options = options.delete_if {|key, value| value.nil?}
       mashup(self.class.get("/autocomplete/json", :query => options.merge(self.default_options)))
     end
@@ -55,24 +55,20 @@ module GooglePlacesAutocomplete
       reference = options.delete(:reference)
 
       if placeid
-        options = {
-          placeid: placeid
-        }
+        options[:placeid] = placeid
       else
-        options = {
-          reference: reference
-        }
+        options[:reference] = reference
       end
 
       mashup(self.class.get("/details/json", :query => options.merge(self.default_options)))
     end
-    
+
     protected
-    
+
     def default_options
       { :sensor => false, :key => @api_key }
     end
-    
+
     def mashup(response)
       case response.code
         when 200


### PR DESCRIPTION
This PR makes it possible to pass additional parameters to the details method. This is very useful to reduce costs because Google charges for each type of information you request and by default it requests everything. So now you can do this:

```ruby
client = GooglePlacesAutocomplete::Client.new(api_key: 'YOUR-KEY')
client.details(placeid: place_id, fields: 'name,international_phone_number,address_component')
```

Also I locked the `httparty` gem to version 0.13.7 because in future versions the parsing of the response breaks due to some changes of the gem. I didn't adjust the parsing logic because I didn't have enough time.