### PR TITLE
Bump to v0.0.4

### DIFF
--- a/lib/google_places_autocomplete/version.rb
+++ b/lib/google_places_autocomplete/version.rb
@@ -1,3 +1,3 @@
 module GooglePlacesAutocomplete
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Hi there 👋 

I'm a colleague of @schurig and I'd like to bump the gem version to `0.0.4` so we can use the feature he added few month ago.

It will require a release on RubyGems IIRC.

Can we pretty please? 🙏 